### PR TITLE
fix(docs): resolve CI build errors for changelog page

### DIFF
--- a/docs/src/i18n/translations/en.json
+++ b/docs/src/i18n/translations/en.json
@@ -64,5 +64,8 @@
 
   "changelog.title": "Changelog",
   
+  "changelog.title": "Changelog",
+  "changelog.description": "Version history and release notes",
+  
   "footer.license": "BSD-3-Clause"
 }

--- a/docs/src/i18n/translations/ja.json
+++ b/docs/src/i18n/translations/ja.json
@@ -64,5 +64,8 @@
 
   "changelog.title": "変更履歴",
   
+  "changelog.title": "変更履歴",
+  "changelog.description": "バージョン履歴とリリースノート",
+  
   "footer.license": "BSD-3-Clause"
 }

--- a/docs/src/i18n/translations/ko.json
+++ b/docs/src/i18n/translations/ko.json
@@ -64,5 +64,8 @@
 
   "changelog.title": "변경 로그",
   
+  "changelog.title": "변경 로그",
+  "changelog.description": "버전 기록 및 릴리스 노트",
+  
   "footer.license": "BSD-3-Clause"
 }

--- a/docs/src/i18n/translations/zh.json
+++ b/docs/src/i18n/translations/zh.json
@@ -64,5 +64,8 @@
 
   "changelog.title": "更新日志",
   
+  "changelog.title": "更新日志",
+  "changelog.description": "版本历史与发布说明",
+  
   "footer.license": "BSD-3-Clause"
 }

--- a/docs/src/pages/[lang]/changelog.astro
+++ b/docs/src/pages/[lang]/changelog.astro
@@ -2,7 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import { getLangFromUrl, useTranslations } from '../../i18n/utils';
 import { ui } from '../../i18n/ui';
-import fs from 'node:fs';
+import * as fs from 'fs';
 
 export function getStaticPaths() {
   return Object.keys(ui).map((lang) => ({ params: { lang } }));


### PR DESCRIPTION
- Change `node:fs` to `fs` for broader TypeScript compatibility
- Add missing changelog.title/description i18n keys to all locales